### PR TITLE
Fix fitness values flow across parallel generations

### DIFF
--- a/genal/crossover_operators.py
+++ b/genal/crossover_operators.py
@@ -13,12 +13,9 @@ from numpy.random import binomial as np_binom
 # TODO: we need more detailed comments
 # TODO: perhaps specific crossover operators should be children of a general class 'CrossoverOperator'?
 
-def single_point_crossover(parent1, parent2, args):
+def single_point_crossover(parent1_genes, parent2_genes, args):
     """Parents will be crossed such that genes from first one (numbered from 0) up to crossover_point
     included shall go to one child, and the rest to the other."""
-
-    parent1_genes = list(parent1.genome)
-    parent2_genes = list(parent2.genome)
 
     if args is None:
         crossover_point = None
@@ -26,7 +23,7 @@ def single_point_crossover(parent1, parent2, args):
         crossover_point = args[0]  # TODO in here we need one argument, so I assume a one-element list... be better
 
     if crossover_point is None:
-        crossover_point = len(parent1_genes) // 2
+        crossover_point = max(0, len(parent1_genes) // 2 - 1)
 
     # TODO: different working with genes whether it's a dict or a list
 
@@ -120,3 +117,9 @@ def plco(parent1, parent2, args):  # partially linear crossover operator
         child2_genes.append(alfa * parent2_genes[index] + beta * parent1_genes[index])
 
     return [child1_genes, child2_genes]
+
+
+if __name__ == '__main__':
+    a, b = single_point_crossover([1, 2, 3, 4], [5, 6, 7, 8], None)
+    print(a)
+    print(b)

--- a/genal/genetic_algorithm.py
+++ b/genal/genetic_algorithm.py
@@ -598,6 +598,7 @@ class GeneticAlgorithm:
         """For new (mutated) genome creation I use the generator passed to the superclass in it's initialisation:"""
         for index in indexes:
             self.current_generation.members[index].change_genes(self.genome_generator(self.args))  # self.manager
+            self.current_generation.members[index].evaluate()
 
     def run(self):
         """This is the main method for an automated run of the Genetic Algorithm, supposed to be used right after this
@@ -608,91 +609,94 @@ class GeneticAlgorithm:
 
         operator_combinations_ids = list(self.operators.keys())
 
-        with self.manager as ga_manager:
-            for _ in range(self.no_generations):
-                """Rival generations are created based on accessible combinations of selection and crossover
-                operators with different processes in parallel:"""
-                rival_members_container = ga_manager.dict()
-                print(f"Creating rival generations")
+        for _ in range(self.no_generations):
+            """Rival generations are created based on accessible combinations of selection and crossover
+            operators with different processes in parallel:"""
+            rival_members_container = self.manager.dict()
+            print(f"Creating rival generations")
 
-                if len(operator_combinations_ids) == 1:
-                    GeneticAlgorithm._create_members_for_rival_generation(
-                        combination_id=0,
-                        members_container=rival_members_container,
-                        parent_generation=self.current_generation,
-                        fitness_function=self.fit_fun,
-                        operators=self.operators, args=self.args
-                    )
-                else:
-                    for combination_id in operator_combinations_ids:
-                        new_worker = Process(
-                            target=GeneticAlgorithm._create_members_for_rival_generation,
-                            args=(
-                                combination_id, rival_members_container, self.current_generation, self.fit_fun,
-                                self.operators, self.args
-                            )
-                        )
-                        new_worker.start()
-                        self.workers.append(new_worker)
-
-                    """After work done, processes are collected and their list reset for new batch of workers:"""
-                    for worker in self.workers:
-                        worker.join()
-
-                """We rebuild the rival_members_container to hold proxies for lists of particular Generation's Members
-                in the shared memory:"""
-                for key in list(rival_members_container.keys()):
-                    rival_members_container[key] = ga_manager.list(rival_members_container.get(key))
-
-                self.workers = []
-
-                """For fitness evaluation as many workers as the CPU allows are created. All members are distributed
-                 between these processes to be evaluated:"""
-                no_workers = cpu_count()
-                no_members = self.pop_size * len(rival_members_container)
-
-                members_per_worker = no_members / no_workers
-                if members_per_worker <= 1:
-                    no_workers = int(no_members)
-
-                indexes_batches = split_indexes(num_members=no_members, num_workers=no_workers)
-
-                print(f"Evaluating fitness of the rival generations. It is iteration number {_}")  # TODO: change from printing to logging
-
-                for index in range(no_workers):
-                    indexes_of_members_to_evaluate = indexes_batches[index]
+            if len(operator_combinations_ids) == 1:
+                GeneticAlgorithm._create_members_for_rival_generation(
+                    combination_id=0,
+                    members_container=rival_members_container,
+                    parent_generation=self.current_generation,
+                    fitness_function=self.fit_fun,
+                    operators=self.operators, args=self.args
+                )
+            else:
+                for combination_id in operator_combinations_ids:
                     new_worker = Process(
-                        target=GeneticAlgorithm._evaluate_members,
+                        target=GeneticAlgorithm._create_members_for_rival_generation,
                         args=(
-                            indexes_of_members_to_evaluate,
-                            self.pop_size,
-                            rival_members_container
-                        ))
+                            combination_id, rival_members_container, self.current_generation, self.fit_fun,
+                            self.operators, self.args
+                        )
+                    )
                     new_worker.start()
                     self.workers.append(new_worker)
 
-                """After evaluation, processes are again joined:"""
+                """After work done, processes are collected and their list reset for new batch of workers:"""
                 for worker in self.workers:
                     worker.join()
 
-                """Reset workers"""
-                self.workers = []
+            """We rebuild the rival_members_container to hold proxies for lists of particular Generation's Members
+            in the shared memory:"""
+            for key in list(rival_members_container.keys()):
+                rival_members_container[key] = self.manager.list(rival_members_container.get(key))
 
-                """Build rival Generations out of members and compose their respective fitness rankings"""
-                for combination_id in operator_combinations_ids:
-                    new_rival_generation = Generation(
-                        generation_members=list(rival_members_container.get(combination_id)),
-                        num_parents_pairs=self.current_generation.num_parents_pairs,
-                        elite_size=self.elite_size,
-                        pool_size=self.pool_size
-                    )
-                    new_rival_generation.create_fitness_ranking()
-                    self.rival_gen_pool[combination_id] = new_rival_generation
+            self.workers = []
 
-                """Last stage of each iteration is to choose the next accepted Generation and mutate it:"""
-                self._choose_best_rival_generation()
-                print(self.best_solution())
-                # self.mutate()  # mutation in here introduces Members with their fitness not evaluated! TODO: make sure mutation is applied to each rival generation after children are created and before fitness is evaluated + that's what's missing and why the code produces more and more of the same children
+            """For fitness evaluation as many workers as the CPU allows are created. All members are distributed
+             between these processes to be evaluated:"""
+            no_workers = cpu_count()
+            no_members = self.pop_size * len(rival_members_container)
+
+            members_per_worker = no_members / no_workers
+            if members_per_worker <= 1:
+                no_workers = int(no_members)
+
+            indexes_batches = split_indexes(num_members=no_members, num_workers=no_workers)
+
+            print(
+                f"Evaluating fitness of the rival generations. It is iteration number {_}")  # TODO: change from printing to logging
+
+            for index in range(no_workers):
+                indexes_of_members_to_evaluate = indexes_batches[index]
+                new_worker = Process(
+                    target=GeneticAlgorithm._evaluate_members,
+                    args=(
+                        indexes_of_members_to_evaluate,
+                        self.pop_size,
+                        rival_members_container
+                    ))
+                new_worker.start()
+                self.workers.append(new_worker)
+
+            """After evaluation, processes are again joined:"""
+            for worker in self.workers:
+                worker.join()
+
+            """Reset workers"""
+            self.workers = []
+
+            """Build rival Generations out of members and compose their respective fitness rankings"""
+            for combination_id in operator_combinations_ids:
+                new_rival_generation = Generation(
+                    generation_members=list(rival_members_container.get(combination_id)),
+                    num_parents_pairs=self.current_generation.num_parents_pairs,
+                    elite_size=self.elite_size,
+                    pool_size=self.pool_size
+                )
+                new_rival_generation.create_fitness_ranking()
+                self.rival_gen_pool[combination_id] = new_rival_generation
+
+            """Last stage of each iteration is to choose the next accepted Generation and mutate it:"""
+            self._choose_best_rival_generation()
+            print(self.best_solution())
+            self.mutate()
+            self.current_generation.fitness_ranking = []
+            self.current_generation.create_fitness_ranking()
+            self.best_fit_history[-1] = self.current_generation.fitness_ranking[0].get('fitness value')
 
     def fitness_plot(self):  # TODO: finish with an optional argument for using plotly or matplotlib
         """Method for plotting fitness values history of the best Members from each accepted Generation."""

--- a/genal/genetic_algorithm.py
+++ b/genal/genetic_algorithm.py
@@ -115,7 +115,6 @@ class Chromosome(ChromosomeInterface):
         Returns:
             float: Fitness value as a float number.
         """
-        print("Using evaluate")
         try:
             if self.fit_fun is not None:
                 result = self.fit_fun(self.genome)
@@ -488,7 +487,7 @@ class GeneticAlgorithm:
         global identification
         selection, crossover = operators.get(combination_id)
 
-        print(f"Process {getpid()}: Creating a new rival Generation")
+        print(f"Process {getpid()}: Creating a new rival Generation")  # TODO: change from printing to logging
 
         new_members = []
         try:
@@ -648,7 +647,7 @@ class GeneticAlgorithm:
 
                 indexes_batches = split_indexes(num_members=no_members, num_workers=no_workers)
 
-                print(f"Evaluating fitness of the rival generations. It is iteration number {_}")
+                print(f"Evaluating fitness of the rival generations. It is iteration number {_}")  # TODO: change from printing to logging
 
                 for index in range(no_workers):
                     indexes_of_members_to_evaluate = indexes_batches[index]

--- a/genal/genetic_algorithm.py
+++ b/genal/genetic_algorithm.py
@@ -503,8 +503,8 @@ class GeneticAlgorithm:
             """We always take 2 consecutive members from the parents_in_order list and pass them to the crossover
             operator to get genomes of new members, for the new generation, to be created."""
             child1_genome, child2_genome = crossover(
-                parents_in_order[2 * index],
-                parents_in_order[2 * index + 1],
+                parents_in_order[2 * index].genome,
+                parents_in_order[2 * index + 1].genome,
                 args.get('crossover')
             )
             new_members.append(Member(
@@ -609,25 +609,35 @@ class GeneticAlgorithm:
         operator_combinations_ids = list(self.operators.keys())
 
         with self.manager as ga_manager:
-            rival_members_container = ga_manager.dict()  # TODO: try to operate with the manager inside the loop, not iterate under the same manager and rival generation pool - or reset the rival generation pool?
             for _ in range(self.no_generations):
                 """Rival generations are created based on accessible combinations of selection and crossover
                 operators with different processes in parallel:"""
+                rival_members_container = ga_manager.dict()
                 print(f"Creating rival generations")
-                for combination_id in operator_combinations_ids:
-                    new_worker = Process(
-                        target=GeneticAlgorithm._create_members_for_rival_generation,
-                        args=(
-                            combination_id, rival_members_container, self.current_generation, self.fit_fun,
-                            self.operators, self.args
-                        )
-                    )
-                    new_worker.start()
-                    self.workers.append(new_worker)
 
-                """After work done, processes are collected and their list reset for new batch of workers:"""
-                for worker in self.workers:
-                    worker.join()
+                if len(operator_combinations_ids) == 1:
+                    GeneticAlgorithm._create_members_for_rival_generation(
+                        combination_id=0,
+                        members_container=rival_members_container,
+                        parent_generation=self.current_generation,
+                        fitness_function=self.fit_fun,
+                        operators=self.operators, args=self.args
+                    )
+                else:
+                    for combination_id in operator_combinations_ids:
+                        new_worker = Process(
+                            target=GeneticAlgorithm._create_members_for_rival_generation,
+                            args=(
+                                combination_id, rival_members_container, self.current_generation, self.fit_fun,
+                                self.operators, self.args
+                            )
+                        )
+                        new_worker.start()
+                        self.workers.append(new_worker)
+
+                    """After work done, processes are collected and their list reset for new batch of workers:"""
+                    for worker in self.workers:
+                        worker.join()
 
                 """We rebuild the rival_members_container to hold proxies for lists of particular Generation's Members
                 in the shared memory:"""
@@ -682,7 +692,7 @@ class GeneticAlgorithm:
                 """Last stage of each iteration is to choose the next accepted Generation and mutate it:"""
                 self._choose_best_rival_generation()
                 print(self.best_solution())
-                # self.mutate()  # mutation in here introduces Members with their fitness not evaluated! TODO: make sure mutation is applied to each rival generation after children are created and before fitness is evaluated
+                # self.mutate()  # mutation in here introduces Members with their fitness not evaluated! TODO: make sure mutation is applied to each rival generation after children are created and before fitness is evaluated + that's what's missing and why the code produces more and more of the same children
 
     def fitness_plot(self):  # TODO: finish with an optional argument for using plotly or matplotlib
         """Method for plotting fitness values history of the best Members from each accepted Generation."""

--- a/genal/genetic_algorithm.py
+++ b/genal/genetic_algorithm.py
@@ -609,7 +609,7 @@ class GeneticAlgorithm:
         operator_combinations_ids = list(self.operators.keys())
 
         with self.manager as ga_manager:
-            rival_members_container = ga_manager.dict()
+            rival_members_container = ga_manager.dict()  # TODO: try to operate with the manager inside the loop, not iterate under the same manager and rival generation pool - or reset the rival generation pool?
             for _ in range(self.no_generations):
                 """Rival generations are created based on accessible combinations of selection and crossover
                 operators with different processes in parallel:"""

--- a/genal/material_endurance_test.py
+++ b/genal/material_endurance_test.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     """Secondly, approach with our GeneticAlgorithm:"""
     new_ga_instance = genetic_algorithm.GeneticAlgorithm(
         initial_pop_size=20,
-        number_of_generations=2,
+        number_of_generations=70,
         elite_size=0,
         args={
             'genome': (np.linspace(start=0, stop=1, num=100000), 6),  # six genes
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         no_parents_pairs=10,  # has to be even for now
         mutation_prob=float(1 / 6)
     )
-    new_ga_instance.run()
+    new_ga_instance.run()  # TODO: after the initial generation once the max fitness changes, but then the returned/printed result at each iteration is exactly the same - why?
 
     best_result = new_ga_instance.best_solution()
 

--- a/genal/material_endurance_test.py
+++ b/genal/material_endurance_test.py
@@ -1,4 +1,5 @@
 import math
+import pygad
 
 import numpy as np
 
@@ -40,7 +41,6 @@ def fitness_function_pyqkd(chromosome):
 
 if __name__ == '__main__':
     """Firstly, solving problem with pygad:"""
-    """
     ga_instance = pygad.GA(
         gene_space=np.linspace(start=0, stop=1, num=100000),
         num_generations=70,
@@ -63,8 +63,7 @@ if __name__ == '__main__':
     print(f"Fitness value of the best solution: {solution_fitness}")
     print(f"It took {generations_number} generations to find an optimal solution.")
 
-    #  ga_instance.plot_fitness()
-    """
+    ga_instance.plot_fitness()
 
     """Secondly, approach with our GeneticAlgorithm:"""
     new_ga_instance = genetic_algorithm.GeneticAlgorithm(


### PR DESCRIPTION
Before the GA was run `with` the `manager` and a container for rival generations was created outside of loop iterating over generations. Now manager is used directly and a fresh container is created for every iteration. Additionally, mutation is again included and the `current_generation` is re-evaluated after mutation is applied. Moreover, slight changes were prototyped in operators.